### PR TITLE
CUQ-5: Mortgage example using gQuant.

### DIFF
--- a/notebook/mortgage_e2e_gquant/mortgage_e2e_gquant.ipynb
+++ b/notebook/mortgage_e2e_gquant/mortgage_e2e_gquant.ipynb
@@ -55,7 +55,8 @@
      "output_type": "stream",
      "text": [
       "class CreateEverFeatures(Node):\n",
-      "    '''\n",
+      "    '''gQuant task/node to calculate delinquecy status period features.\n",
+      "    Refer to columns_setup method for the columns produced.\n",
       "    '''\n",
       "    def columns_setup(self):\n",
       "        self.required = OrderedDict([\n",
@@ -100,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We create a worfklow by defining tasks and specifying their configuration (parameters) and inputs (for basics tutorial on gQuant refer to [01_tutorial.ipynb](https://github.com/rapidsai/gQuant/blob/master/notebook/01_tutorial.ipynb) and custom plugins [05_customize_nodes.ipynb](https://github.com/rapidsai/gQuant/blob/master/notebook/05_customize_nodes.ipynb)). The workflow to calculate the mortgage features and delinquecy is defined in the `mortgage_workflow_def` function in `mortgage_common` module. Its code is shown below."
+    "We create a worfklow by defining tasks and specifying their configuration (parameters) and inputs (for basics tutorial on gQuant refer to [01_tutorial.ipynb](https://github.com/rapidsai/gQuant/blob/master/notebook/01_tutorial.ipynb) and custom plugins [05_customize_nodes.ipynb](https://github.com/rapidsai/gQuant/blob/master/notebook/05_customize_nodes.ipynb)). The workflow to calculate the mortgage features and delinquecy is defined in the `mortgage_etl_workflow_def` function in `mortgage_common` module. Its code is shown below."
    ]
   },
   {
@@ -112,8 +113,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "def mortgage_workflow_def(csvfile_names=None, csvfile_acqdata=None,\n",
-      "                          csvfile_perfdata=None):\n",
+      "def mortgage_etl_workflow_def(\n",
+      "        csvfile_names=None, csvfile_acqdata=None,\n",
+      "        csvfile_perfdata=None):\n",
+      "    '''Define the ETL (extract-transform-load) portion of the mortgage\n",
+      "    workflow.\n",
+      "\n",
+      "    :returns: gQuant workflow. Currently a simple list of dictionaries. Each\n",
+      "        dict specifies a task per TaskSpecSchema.\n",
+      "    :rtype: list\n",
+      "    '''\n",
       "    from gquant.dataframe_flow.node import TaskSpecSchema\n",
       "\n",
       "    _basedir = os.path.dirname(__file__)\n",
@@ -222,9 +231,9 @@
    ],
    "source": [
     "import inspect\n",
-    "from mortgage_common import mortgage_workflow_def\n",
+    "from mortgage_common import mortgage_etl_workflow_def\n",
     "\n",
-    "print(inspect.getsource(mortgage_workflow_def))"
+    "print(inspect.getsource(mortgage_etl_workflow_def))"
    ]
   },
   {
@@ -255,7 +264,7 @@
     "from gquant.dataframe_flow import viz_graph\n",
     "from nxpd import draw\n",
     "\n",
-    "task_list = mortgage_workflow_def()\n",
+    "task_list = mortgage_etl_workflow_def()\n",
     "task_graph = viz_graph(task_list)\n",
     "draw(task_graph, show='ipynb')"
    ]
@@ -285,7 +294,7 @@
     "import os\n",
     "import gquant.dataframe_flow as dff\n",
     "from mortgage_common import (\n",
-    "    mortgage_workflow_def, MortgageTaskNames)\n",
+    "    mortgage_etl_workflow_def, MortgageTaskNames)\n",
     "\n",
     "# mortgage_data_path = '/datasets/rapids_data/mortgage'\n",
     "mortgage_data_path = './mortgage_data'\n",
@@ -299,7 +308,7 @@
     "csvfile_acqdata = os.path.join(acq_data_path, 'Acquisition_2000Q1.txt')\n",
     "csvfile_perfdata = os.path.join(perf_data_path, 'Performance_2000Q1.txt_0')\n",
     "\n",
-    "gquant_task_list = mortgage_workflow_def(\n",
+    "gquant_task_list = mortgage_etl_workflow_def(\n",
     "    csvfile_names, csvfile_acqdata, csvfile_perfdata)\n",
     "out_list = [MortgageTaskNames.final_perf_acq_task_name]\n",
     "\n",
@@ -353,7 +362,7 @@
      "output_type": "stream",
      "text": [
       "pid, process_name, used_gpu_memory [MiB]\n",
-      "40117, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 1827 MiB\n"
+      "9617, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 1827 MiB\n"
      ]
     }
    ],
@@ -378,7 +387,7 @@
      "output_type": "stream",
      "text": [
       "pid, process_name, used_gpu_memory [MiB]\n",
-      "40117, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 171 MiB\n"
+      "9617, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 171 MiB\n"
      ]
     }
    ],
@@ -477,7 +486,7 @@
     "import gquant.dataframe_flow as dff\n",
     "\n",
     "from mortgage_common import (\n",
-    "    mortgage_workflow_def, generate_mortgage_gquant_run_params_list,\n",
+    "    mortgage_etl_workflow_def, generate_mortgage_gquant_run_params_list,\n",
     "    MortgageTaskNames)\n",
     "\n",
     "start_year = 2000\n",
@@ -490,7 +499,7 @@
     "# ADJUST YOUR MORTGAGE DATAPATH IF DIFFERENT\n",
     "mortgage_data_path = './mortgage_data'\n",
     "\n",
-    "gquant_task_list = mortgage_workflow_def()\n",
+    "gquant_task_list = mortgage_etl_workflow_def()\n",
     "mortgage_run_params_dict_list = generate_mortgage_gquant_run_params_list(\n",
     "    mortgage_data_path, start_year, end_year, part_count, gquant_task_list)\n",
     "\n",
@@ -576,7 +585,7 @@
    "source": [
     "Refer to `MortgageWorkflowRunner` and `XgbMortgageTrainer` in the `mortgage_gquant_plugins.py` module for the details of the mortage workflow runner and xgboost trainer tasks.\n",
     "\n",
-    "Note the novel manner in which gQuant is used. The `mortgage_workflow_runner` actually runs another gQuant workflow defined by `mortgage_workflow_def()` for each set of acquisition and performance csv files. The output from `mortgage_workflow_runner` is a pandas dataframe (concatenated from processing multiple `final_per_acq_df` dataframes). The `xgb_trainer` is used in an atypical manner. It does not output a dataframe, instead it produces an XGBoost booster. Even though we mostly focus on dataframe flow with gQuant, if the tasks input/output something beside dataframes then gQuant will still run the workflow. When a task does not output a dataframe then gQuant does not perform columns validation. Currently, the responsibility is on the end-user to validate or make sure the input/output types match for the wired non-dataframe tasks. Above only the `xgb_trainer` task's output is not a datframe.\n",
+    "Note the novel manner in which gQuant is used. The `mortgage_workflow_runner` actually runs another gQuant workflow defined by `mortgage_etl_workflow_def()` for each set of acquisition and performance csv files. The output from `mortgage_workflow_runner` is a pandas dataframe (concatenated from processing multiple `final_per_acq_df` dataframes). The `xgb_trainer` is used in an atypical manner. It does not output a dataframe, instead it produces an XGBoost booster. Even though we mostly focus on dataframe flow with gQuant, if the tasks input/output something beside dataframes then gQuant will still run the workflow. When a task does not output a dataframe then gQuant does not perform columns validation. Currently, the responsibility is on the end-user to validate or make sure the input/output types match for the wired non-dataframe tasks. Above only the `xgb_trainer` task's output is not a datframe.\n",
     "\n",
     "We can run the workflow now and obtain the XGBoost trained booster. You can monitor the GPU utilization in a terminal using `nvidia-smi`. On my node I have 125GB of host RAM and two 16GB GPU cards. I am able to process 12 dataframes. If I load more than 12 dataframes, then the workflow crashes during DMatrix creation due to out of memory error. The DMatrix instantiation seems to inflate the data temporarily and I run out of memory on the host. In a terminal you can watch with nvidia-smi the utilization on the GPU. During XGBoost training I typically observe:\n",
     "\n",
@@ -642,14 +651,14 @@
       "perfdata:INFO: LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_1_1\n",
       "acqdata:INFO: LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
       "mortgage_workflow_runner:INFO: LOADED 12 FRAMES\n",
-      "mortgage_workflow_runner:INFO: HOST RAM (MB) TOTAL 128902; USED 17376; FREE 91230\n",
+      "mortgage_workflow_runner:INFO: HOST RAM (MB) TOTAL 128904; USED 17348; FREE 92898\n",
       "mortgage_workflow_runner:INFO: RUN PYTHON GARBAGE COLLECTION TO MAYBE CLEAR CPU AND GPU MEMORY\n",
-      "mortgage_workflow_runner:INFO: HOST RAM (MB) TOTAL 128902; USED 17376; FREE 91230\n",
+      "mortgage_workflow_runner:INFO: HOST RAM (MB) TOTAL 128904; USED 17349; FREE 92898\n",
       "mortgage_workflow_runner:INFO: USING ARROW\n",
       "mortgage_workflow_runner:INFO: ARROW TO PANDAS\n",
-      "mortgage_workflow_runner:INFO: HOST RAM (MB) TOTAL 128902; USED 32792; FREE 75814\n",
+      "mortgage_workflow_runner:INFO: HOST RAM (MB) TOTAL 128904; USED 32763; FREE 77483\n",
       "xgb_trainer:INFO: JUST BEFORE DMATRIX\n",
-      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 17389; FREE 91217\n",
+      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128904; USED 17360; FREE 92870\n",
       "xgb_trainer:INFO: CREATING DMATRIX\n"
      ]
     },
@@ -666,12 +675,12 @@
      "output_type": "stream",
      "text": [
       "xgb_trainer:INFO: JUST AFTER DMATRIX\n",
-      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 63622; FREE 44983\n",
+      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128904; USED 63598; FREE 46631\n",
       "xgb_trainer:INFO: CLEAR MEMORY JUST BEFORE XGBOOST TRAINING\n",
-      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 48546; FREE 60059\n",
+      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128904; USED 48521; FREE 61708\n",
       "xgb_trainer:INFO: RUNNING XGBOOST TRAINING\n",
       "XGBOOST BOOSTER:\n",
-      " <xgboost.core.Booster object at 0x2adbc7c4d940>\n"
+      " <xgboost.core.Booster object at 0x2b8eaff85a20>\n"
      ]
     }
    ],
@@ -695,31 +704,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Specifying ngpus=2 will split the training across two GPUs, but in a non-distributed manner (this approach is being [deprecated](https://xgboost.readthedocs.io/en/latest/gpu/#single-node-multi-gpu) in favor of distributed). Let's re-run below on 2 GPUs for completeness sake. If you don't have at least two GPUs do not run the cell below."
+    "Specifying ngpus=2 will split the training across two GPUs, but in a non-distributed manner (this approach is being [deprecated](https://xgboost.readthedocs.io/en/latest/gpu/#single-node-multi-gpu) in favor of distributed). If you would like to run with 2 GPUs in this manner, convert the cell below to code (from raw format to code select cell and press Esc+y), and run below on 2 GPUs. If you don't have at least two GPUs do not run the cell below."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
+   "cell_type": "raw",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "xgb_trainer:INFO: JUST BEFORE DMATRIX\n",
-      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 17500; FREE 91105\n",
-      "xgb_trainer:INFO: CREATING DMATRIX\n",
-      "xgb_trainer:INFO: JUST AFTER DMATRIX\n",
-      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 63738; FREE 44867\n",
-      "xgb_trainer:INFO: CLEAR MEMORY JUST BEFORE XGBOOST TRAINING\n",
-      "xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 48662; FREE 59942\n",
-      "xgb_trainer:INFO: RUNNING XGBOOST TRAINING\n",
-      "XGBOOST BOOSTER:\n",
-      " <xgboost.core.Booster object at 0x2adbc47b9470>\n"
-     ]
-    }
-   ],
    "source": [
     "# CLEAN MEMORY FROM RUN BEFORE\n",
     "import gc\n",
@@ -755,7 +745,7 @@
     "    'verbose':           True\n",
     "}\n",
     "\n",
-    "# By loading existing dataframes no need ot re-run\n",
+    "# By loading existing dataframes no need to re-run\n",
     "# mortgage_workflow_runner task.\n",
     "replace_spec = {\n",
     "    MortgageTaskNames.mortgage_workflow_runner_task_name: {\n",
@@ -797,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -805,12 +795,11 @@
      "output_type": "stream",
      "text": [
       "              total        used        free      shared  buff/cache   available\n",
-      "Mem:         128902       49609       58973        6541       20320       69305\n",
+      "Mem:         128904       49325       60901        6250       18676       69887\n",
       "Swap:             0           0           0\n",
       "\n",
       "pid, process_name, used_gpu_memory [MiB]\n",
-      "40117, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 5965 MiB\n",
-      "40117, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 5905 MiB\n"
+      "9617, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 11023 MiB\n"
      ]
     }
    ],
@@ -838,7 +827,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -849,12 +838,12 @@
       "\n",
       "HOST RAM\n",
       "              total        used        free      shared  buff/cache   available\n",
-      "Mem:         128902        1533      114394        6518       12974      117415\n",
+      "Mem:         128904        2059      108169        6248       18675      117155\n",
       "Swap:             0           0           0\n",
       "\n",
       "GPU STATUS\n",
       "pid, process_name, used_gpu_memory [MiB]\n",
-      "No running processes found\n",
+      "9617, /home/avolkov/progs/python_installs/miniconda3/envs/py36-rapids/bin/python, 189 MiB\n",
       "\n",
       "\n",
       "\n",
@@ -869,7 +858,7 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3>Client</h3>\n",
        "<ul>\n",
-       "  <li><b>Scheduler: </b>tcp://127.0.0.1:43669\n",
+       "  <li><b>Scheduler: </b>tcp://127.0.0.1:35199\n",
        "  <li><b>Dashboard: </b><a href='http://127.0.0.1:8787/status' target='_blank'>http://127.0.0.1:8787/status</a>\n",
        "</ul>\n",
        "</td>\n",
@@ -885,10 +874,10 @@
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://127.0.0.1:43669' processes=2 cores=8>"
+       "<Client: scheduler='tcp://127.0.0.1:35199' processes=2 cores=8>"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -952,7 +941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -962,7 +951,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -976,7 +965,7 @@
     "import gquant.dataframe_flow as dff\n",
     "\n",
     "from mortgage_common import (\n",
-    "    mortgage_workflow_def, generate_mortgage_gquant_run_params_list,\n",
+    "    mortgage_etl_workflow_def, generate_mortgage_gquant_run_params_list,\n",
     "    MortgageTaskNames)\n",
     "\n",
     "\n",
@@ -984,7 +973,7 @@
     "mortgage_data_path = './mortgage_data'\n",
     "\n",
     "# Using some default csv files for testing.\n",
-    "gquant_task_list = mortgage_workflow_def()\n",
+    "gquant_task_list = mortgage_etl_workflow_def()\n",
     "\n",
     "start_year = 2000\n",
     "end_year = 2001  # end_year is inclusive\n",
@@ -1096,7 +1085,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1105,87 +1094,87 @@
      "text": [
       "dask_mortgage_workflow_runner:INFO: TRYING TO LOAD 18 FRAMES\n",
       "dask_mortgage_workflow_runner:INFO: SPLIT MORTGAGE DATA INTO 2 CHUNKS AMONGST 2 WORKERS\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:07.895 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 RUNNING MORTGAGE gQUANT DataframeFlow\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:07.895 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 NCCL_P2P_DISABLE: 1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:07.895 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 CUDA_VISIBLE_DEVICES: 1,0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:11.890 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2000Q1.txt_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:52.918 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2000Q1.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:56.586 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 1 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:56.617 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2000Q2.txt_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:40:39.610 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2000Q2.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:40:41.606 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 2 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:40:42.035 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2000Q3.txt_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:20.657 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2000Q3.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:23.979 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 3 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:24.058 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2000Q4.txt_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:25.355 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2000Q4.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:26.240 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 4 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:26.971 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2000Q4.txt_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:35.556 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2000Q4.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:37.579 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 5 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:37.594 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q1.txt_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:41.171 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q1.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:42.699 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 6 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:43.232 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q1.txt_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:24.494 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q1.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:26.582 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 7 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:27.541 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_1_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:51.974 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:53.715 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 8 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:53.746 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_1_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:27.844 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:29.961 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 9 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:30.271 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 HOST RAM (MB) TOTAL 128902; USED 25760; FREE 81403\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:30.272 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 RUN PYTHON GARBAGE COLLECTION TO MAYBE CLEAR CPU AND GPU MEMORY\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:30.530 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 HOST RAM (MB) TOTAL 128902; USED 25760; FREE 81397\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:30.530 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 USING ARROW\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:30.530 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 ARROW TO PANDAS\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:31.669 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 HOST RAM (MB) TOTAL 128902; USED 37630; FREE 69492\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:07.895 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 RUNNING MORTGAGE gQUANT DataframeFlow\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:07.895 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 NCCL_P2P_DISABLE: 1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:07.895 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 CUDA_VISIBLE_DEVICES: 0,1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:11.889 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_0_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:39:51.672 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:40:00.075 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 1 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:40:00.526 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_0_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:06.758 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:08.897 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 2 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:09.182 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_1_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:13.399 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:14.886 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 3 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:15.465 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_1_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:37.530 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:39.569 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 4 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:39.593 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_0_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:46.775 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:48.217 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 5 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:41:48.680 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_0_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:22.489 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:24.621 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 6 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:24.633 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q4.txt_1_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:55.649 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q4.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:57.766 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 7 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:42:58.172 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q4.txt_1_0\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:27.090 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q4.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:29.204 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 8 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:29.224 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q4.txt_0_1\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:52.584 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q4.txt\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:54.660 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 9 FRAMES\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:54.716 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 HOST RAM (MB) TOTAL 128902; USED 27457; FREE 79095\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:54.716 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 RUN PYTHON GARBAGE COLLECTION TO MAYBE CLEAR CPU AND GPU MEMORY\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:55.026 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 HOST RAM (MB) TOTAL 128902; USED 27458; FREE 79094\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:55.026 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 USING ARROW\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:55.026 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 ARROW TO PANDAS\n",
-      "dask_mortgage_workflow_runner:INFO: 14:43:56.050 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 HOST RAM (MB) TOTAL 128902; USED 40011; FREE 66542\n",
-      "dask_mortgage_workflow_runner:INFO: CLIENT INFO WHO HAS WHAT: {'mortgage_workflow_runner-d362db91d71bb24450cfb524ef324f77': ('tcp://127.0.0.1:43747',), 'mortgage_workflow_runner-b5743315029c7d5a29e92ba72b9892be': ('tcp://127.0.0.1:34498',)}\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:29.327 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 RUNNING MORTGAGE gQUANT DataframeFlow\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:29.327 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 NCCL_P2P_DISABLE: 1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:29.327 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 CUDA_VISIBLE_DEVICES: 0,1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:33.421 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2000Q1.txt_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:43.085 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2000Q1.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:45.559 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 1 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:45.569 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2000Q2.txt_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:50.005 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2000Q2.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:51.671 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 2 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:51.683 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2000Q3.txt_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:57.043 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2000Q3.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:58.903 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 3 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:59.089 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2000Q4.txt_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:00.461 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2000Q4.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:02.399 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 4 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:03.092 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2000Q4.txt_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:08.396 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2000Q4.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:10.460 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 5 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:10.657 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q1.txt_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:15.215 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q1.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:16.826 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 6 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:16.978 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q1.txt_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:21.488 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q1.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:23.450 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 7 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:23.718 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_1_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:27.000 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:28.790 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 8 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:29.097 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_1_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:35.848 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-0 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:37.981 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 LOADED 9 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:38.430 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 HOST RAM (MB) TOTAL 128904; USED 18453; FREE 90733\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:38.430 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 RUN PYTHON GARBAGE COLLECTION TO MAYBE CLEAR CPU AND GPU MEMORY\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:38.612 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 HOST RAM (MB) TOTAL 128904; USED 18452; FREE 90735\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:38.612 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 USING ARROW\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:38.612 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 ARROW TO PANDAS\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:39.627 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-0 HOST RAM (MB) TOTAL 128904; USED 30395; FREE 78791\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:29.327 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 RUNNING MORTGAGE gQUANT DataframeFlow\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:29.327 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 NCCL_P2P_DISABLE: 1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:29.327 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 CUDA_VISIBLE_DEVICES: 1,0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:33.421 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_0_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:41.426 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:43.591 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 1 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:43.600 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q2.txt_0_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:47.955 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q2.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:50.343 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 2 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:50.351 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_1_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:52.896 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:54.339 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 3 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:32:54.351 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_1_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:42.574 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:44.731 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 4 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:33:44.744 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_0_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:00.805 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:02.141 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 5 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:02.150 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q3.txt_0_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:26.221 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q3.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:28.239 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 6 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:28.248 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q4.txt_1_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:38.005 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q4.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:42.556 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 7 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:34:42.565 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q4.txt_1_0\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:12.334 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q4.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:14.552 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 8 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:14.560 distributed.worker.csv_mortgage_performance_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/perf/Performance_2001Q4.txt_0_1\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:37.469 distributed.worker.csv_mortgage_acquisition_data_loader:INFO: WORKER gpu-1 LOADING: ./mortgage_data/acq/Acquisition_2001Q4.txt\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:39.433 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 LOADED 9 FRAMES\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:39.499 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 HOST RAM (MB) TOTAL 128904; USED 27580; FREE 79216\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:39.499 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 RUN PYTHON GARBAGE COLLECTION TO MAYBE CLEAR CPU AND GPU MEMORY\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:39.720 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 HOST RAM (MB) TOTAL 128904; USED 27574; FREE 79221\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:39.720 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 USING ARROW\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:39.721 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 ARROW TO PANDAS\n",
+      "dask_mortgage_workflow_runner:INFO: 10:35:40.802 distributed.worker.mortgage_workflow_runner:INFO: WORKER gpu-1 HOST RAM (MB) TOTAL 128904; USED 40135; FREE 66660\n",
+      "dask_mortgage_workflow_runner:INFO: CLIENT INFO WHO HAS WHAT: {'mortgage_workflow_runner-be5c441cc0011dfe077296dce40bef40': ('tcp://127.0.0.1:32858',), 'mortgage_workflow_runner-76eb03dfba52a2de7b3797cf91d54667': ('tcp://127.0.0.1:44987',)}\n",
       "dask_xgb_trainer:INFO: CREATING DMATRIX SERIALLY ACROSS 2 WORKERS\n",
-      "dask_xgb_trainer:INFO: 14:44:09.022 distributed.worker.make_xgb_dmatrix:INFO: CREATING DMATRIX ON WORKER gpu-1\n",
-      "dask_xgb_trainer:INFO: 14:45:22.435 distributed.worker.make_xgb_dmatrix:INFO: CREATING DMATRIX ON WORKER gpu-0\n",
+      "dask_xgb_trainer:INFO: 10:35:41.565 distributed.worker.make_xgb_dmatrix:INFO: CREATING DMATRIX ON WORKER gpu-0\n",
+      "dask_xgb_trainer:INFO: 10:37:01.346 distributed.worker.make_xgb_dmatrix:INFO: CREATING DMATRIX ON WORKER gpu-1\n",
       "dask_xgb_trainer:INFO: JUST AFTER DMATRIX\n",
-      "dask_xgb_trainer:INFO: HOST RAM (MB) TOTAL 128902; USED 76917; FREE 39053\n",
+      "dask_xgb_trainer:INFO: HOST RAM (MB) TOTAL 128904; USED 77004; FREE 39081\n",
       "dask_xgb_trainer:INFO: RUNNING XGBOOST TRAINING USING DASK-XGBOOST\n",
       "XGBOOST BOOSTER:\n",
-      " <xgboost.core.Booster object at 0x2ac1348bb518>\n"
+      " <xgboost.core.Booster object at 0x2b8eca2d4d30>\n"
      ]
     }
    ],
@@ -1235,7 +1224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebook/mortgage_e2e_gquant/mortgage_run_workflow_daskdistrib.py
+++ b/notebook/mortgage_e2e_gquant/mortgage_run_workflow_daskdistrib.py
@@ -20,7 +20,7 @@ from dask.distributed import Client
 # from distributed import Client
 
 from mortgage_common import (
-    mortgage_workflow_def, generate_mortgage_gquant_run_params_list,
+    mortgage_etl_workflow_def, generate_mortgage_gquant_run_params_list,
     MortgageTaskNames)
 
 
@@ -57,9 +57,10 @@ def main():
     # csvfile_acqdata = os.path.join(acq_data_path, 'Acquisition_2000Q1.txt')
     # csvfile_perfdata = \
     #     os.path.join(perf_data_path, 'Performance_2000Q1.txt_0')
-    # mortgage_workflow_def(csvfile_names, csvfile_acqdata, csvfile_perfdata)
+    # mortgage_etl_workflow_def(
+    #     csvfile_names, csvfile_acqdata, csvfile_perfdata)
 
-    gquant_task_list = mortgage_workflow_def()
+    gquant_task_list = mortgage_etl_workflow_def()
 
     start_year = 2000
     end_year = 2001  # end_year is inclusive

--- a/notebook/mortgage_e2e_gquant/mortgage_run_workflow_local.py
+++ b/notebook/mortgage_e2e_gquant/mortgage_run_workflow_local.py
@@ -10,7 +10,7 @@ import gquant.dataframe_flow as dff
 
 
 from mortgage_common import (
-    mortgage_workflow_def, generate_mortgage_gquant_run_params_list,
+    mortgage_etl_workflow_def, generate_mortgage_gquant_run_params_list,
     MortgageTaskNames)
 
 
@@ -27,9 +27,10 @@ def main():
     # csvfile_acqdata = os.path.join(acq_data_path, 'Acquisition_2000Q1.txt')
     # csvfile_perfdata = \
     #     os.path.join(perf_data_path, 'Performance_2000Q1.txt_0')
-    # mortgage_workflow_def(csvfile_names, csvfile_acqdata, csvfile_perfdata)
+    # mortgage_etl_workflow_def(
+    #     csvfile_names, csvfile_acqdata, csvfile_perfdata)
 
-    gquant_task_list = mortgage_workflow_def()
+    gquant_task_list = mortgage_etl_workflow_def()
 
     start_year = 2000
     end_year = 2001  # end_year is inclusive


### PR DESCRIPTION
Cleanup mortgage plugins logger.
Add docstrings.
Rename mortgage_workflow_def to mortgage_etl_workflow_def.

Disable the non-dask multigpu xgboost training example in the notebook. That approach still works but it is deprecated. Can be re-enabled in the notebook if desired.
