### PR TITLE
Fix 40 - Remove debug info

### DIFF
--- a/gquant/plugin_nodes/analysis/barPlotNode.py
+++ b/gquant/plugin_nodes/analysis/barPlotNode.py
@@ -29,7 +29,6 @@ class BarPlotNode(Node):
         stock = inputs[0]
         num_points = self.conf['points']
         stride = max(len(stock) // num_points, 1)
-        print('bar plot', len(stock), stride)
         label = 'stock'
         if 'label' in self.conf:
             label = self.conf['label']

--- a/gquant/plugin_nodes/analysis/cumReturnNode.py
+++ b/gquant/plugin_nodes/analysis/cumReturnNode.py
@@ -33,7 +33,6 @@ class CumReturnNode(Node):
             label = self.conf['label']
         num_points = self.conf['points']
         stride = max(len(input_df) // num_points, 1)
-        print('cumulative return', len(input_df), stride)
         date_co = DateScale()
         linear_co = LinearScale()
         yax = Axis(label='Cumulative return', scale=linear_co,


### PR DESCRIPTION
Fix issue #40 - Remove debug info from `barPlotNote.py` and `cumReturnNode.py`.