### PR TITLE
Explicit casting dataframe/series to numpy array, and fix OB indexing

### DIFF
--- a/gquant/plugin_nodes/analysis/barPlotNode.py
+++ b/gquant/plugin_nodes/analysis/barPlotNode.py
@@ -1,5 +1,6 @@
 from gquant.dataframe_flow import Node
 from bqplot import Axis, LinearScale, DateScale, Figure, OHLC, Bars, Tooltip
+import cupy as cp
 
 
 class BarPlotNode(Node):
@@ -39,14 +40,14 @@ class BarPlotNode(Node):
         ax_y = Axis(label='Price', scale=sc, orientation='vertical',
                     tick_format='0.0f')
         # Construct the marks
-        ohlc = OHLC(x=stock['datetime'][::stride],
-                    y=stock[['open', 'high', 'low', 'close']]
-                    .as_gpu_matrix()[::stride, :],
+        ohlc = OHLC(x=stock['datetime'][::stride].to_array(),
+                    y=cp.asnumpy(stock[['open', 'high', 'low', 'close']]
+                                 .as_gpu_matrix()[::stride, :]),
                     marker='candle', scales={'x': dt_scale, 'y': sc},
                     format='ohlc', stroke='blue',
                     display_legend=True, labels=[label])
-        bar = Bars(x=stock['datetime'][::stride],
-                   y=stock['volume'][::stride],
+        bar = Bars(x=stock['datetime'][::stride].to_array(),
+                   y=stock['volume'][::stride].to_array(),
                    scales={'x': dt_scale, 'y': sc2},
                    padding=0.2)
         def_tt = Tooltip(fields=['x', 'y'], formats=['%Y-%m-%d', '.2f'])

--- a/gquant/plugin_nodes/analysis/cumReturnNode.py
+++ b/gquant/plugin_nodes/analysis/cumReturnNode.py
@@ -39,8 +39,8 @@ class CumReturnNode(Node):
                    orientation='vertical')
         xax = Axis(label='Time', scale=date_co, orientation='horizontal')
         panzoom_main = PanZoom(scales={'x': [date_co]})
-        line = Lines(x=input_df['datetime'][::stride],
-                     y=(input_df['strategy_returns'].cumsum())[::stride],
+        line = Lines(x=input_df['datetime'][::stride].to_array(),
+                     y=(input_df['strategy_returns'].cumsum())[::stride].to_array(),
                      scales={'x': date_co, 'y': linear_co},
                      colors=['blue'], labels=[label], display_legend=True)
         new_fig = Figure(marks=[line], axes=[yax, xax], title='P & L',

--- a/gquant/plugin_nodes/analysis/linePlotNode.py
+++ b/gquant/plugin_nodes/analysis/linePlotNode.py
@@ -38,8 +38,8 @@ class LinePlotNode(Node):
             col_name = line['column']
             label_name = line['label']
             color = line['color']
-            line = Lines(x=input_df['datetime'][::stride],
-                         y=input_df[col_name][::stride],
+            line = Lines(x=input_df['datetime'][::stride].to_array(),
+                         y=input_df[col_name][::stride].to_array(),
                          scales={'x': date_co, 'y': linear_co}, colors=[color],
                          labels=[label_name], display_legend=True)
             lines.append(line)

--- a/notebooks/02_single_stock_trade.ipynb
+++ b/notebooks/02_single_stock_trade.ipynb
@@ -136,7 +136,7 @@
     "    cum_return.marks[0].labels = [symbol]\n",
     "    signals.layout.height = figure_height\n",
     "    signals.layout.width = figure_width\n",
-    "    bar_figure.axes = [bar_figure.axes[1]]\n",
+    "    bar_figure.axes = [bar_figure.axes[0]]\n",
     "    cum_return.axes = [cum_return.axes[0]]\n",
     "    output = widgets.VBox([bar_figure, cum_return, signals])\n",
     "\n",


### PR DESCRIPTION
Greetings! 
For `02_single_stock_trade.ipynb` to work with `bqplot` in my environment, I had to explicitly cast some dataframe slices to `numpy` array.  Also `bar_figure.axes[1]` would give out of bound index error, `s/1/0/` moved it along....

I'm on `cudf 0.14` and `bqplot 0.12.12`.